### PR TITLE
Reverted back to my function for finding the nearest gate.

### DIFF
--- a/SOURCE/stargatetech2/transport/stargates/StargateNetwork.java
+++ b/SOURCE/stargatetech2/transport/stargates/StargateNetwork.java
@@ -295,14 +295,14 @@ public class StargateNetwork implements IStargateNetwork{
 	public Address findNearestStargate(World w, int x, int y, int z, int r) {
 		if(!isLoaded) return null;
 		int dim = w.provider.dimensionId;
-		int nearest = r;
+		double nearest = r;
 		Address addr = null;
 		for(AddressMapping map : addresses.values()){
 			if(map.getDimension() == dim){
 				int dx = x - map.getXCoord();
 				int dy = y - map.getYCoord();
 				int dz = z - map.getZCoord();
-				int dst = (int)Math.sqrt(dx*dx + dy*dy + dz*dz);
+				double dst = Math.sqrt(dx*dx + dy*dy + dz*dz);
 				
 				if (dst < nearest || nearest < 0) {
 					nearest = dst;


### PR DESCRIPTION
If `r = -1`, `nearest` would become 1 and the search radius is then 1.
Checking if `r < 0` was faulty because `r` was never changed (So if it was -1, it would always be less than 0 and cause an update of the nearest address, regardless of whether or not it is actually closer).
