### PR TITLE
Accidental ! causing gates not to dial unless cancelled.

### DIFF
--- a/SOURCE/stargatetech2/transport/stargates/StargateNetwork.java
+++ b/SOURCE/stargatetech2/transport/stargates/StargateNetwork.java
@@ -120,7 +120,7 @@ public class StargateNetwork implements IStargateNetwork{
 	}
 	
 	public DialError dial(Address source, Address destination, int timeout){
-		if (!MinecraftForge.EVENT_BUS.post(new DialEvent.Pre(source, destination, timeout))) return null;
+		if (MinecraftForge.EVENT_BUS.post(new DialEvent.Pre(source, destination, timeout))) return null;
 		DialError error = null;
 		AddressMapping srcmap = addresses.get(source);
 		AddressMapping dstmap = addresses.get(destination);


### PR DESCRIPTION
_So it returns `true` if it was cancelled!_ - Matchlighter
