### PR TITLE
Fixed range check for large coordinates

### DIFF
--- a/src/main/java/lordfokas/stargatetech2/transport/stargates/StargateNetwork.java
+++ b/src/main/java/lordfokas/stargatetech2/transport/stargates/StargateNetwork.java
@@ -207,9 +207,9 @@ public class StargateNetwork implements IStargateNetwork{
 		int dim = w.provider.dimensionId;
 		for(AddressMapping map : addresses.values()){
 			if(map.getDimension() == dim){
-				int dx = x - map.getXCoord();
-				int dy = y - map.getYCoord();
-				int dz = z - map.getZCoord();
+				double dx = x - map.getXCoord();
+				double dy = y - map.getYCoord();
+				double dz = z - map.getZCoord();
 				if(dx*dx + dy*dy + dz*dz < ConfigServer.stargateMinDistance){
 					return false;
 				}


### PR DESCRIPTION
When I have first Stargate at (50 000, 60, 50 000) and second at ( -50 000, 60, -50 000) then integer max value is insufficient.
Minecraft world limit is 30 000 000. 
The worst case is ((60 000 000^2)*2) + (255^2) = 7.200000000065e+15. 
Double max value is 1.79769e+308.